### PR TITLE
Update PawnController

### DIFF
--- a/code/pawn/PawnController.Util.cs
+++ b/code/pawn/PawnController.Util.cs
@@ -47,7 +47,7 @@ public partial class PawnController
 
 		Entity.ApplyAbsoluteImpulse( jumpVector );
 
-		previousWallrunSide = Wallrunning;
+		previousWallrunNormal = CurrentWall.Normal;
 		Wallrunning = 0;
 	}
 
@@ -104,7 +104,7 @@ public partial class PawnController
 		AddEvent( "grounded" );
 
 		Wallrunning = 0;
-		previousWallrunSide = 0;
+		previousWallrunNormal = Vector3.Zero;
 
 		parkouredSinceJumping = false;
 		parkouredBeforeLanding = false;

--- a/code/pawn/PawnController.Wallrunning.cs
+++ b/code/pawn/PawnController.Wallrunning.cs
@@ -40,7 +40,7 @@ public partial class PawnController
 		{
 			Wallrunning = 0;
 			wallrunSinceJumping = false;
-			previousWallrunSide = 0;
+			previousWallrunNormal = Vector3.Zero;
 		}
 
 		CurrentWall = traceWall.traceResult;
@@ -87,7 +87,7 @@ public partial class PawnController
 
 		var traceWall = CheckForWall();
 
-		if ( CanWallrun( traceWall ) && previousWallrunSide != traceWall.side )
+		if ( CanWallrun( traceWall ) && previousWallrunNormal != traceWall.traceResult.Normal )
 		{
 			InitiateWallrun( traceWall );
 
@@ -109,7 +109,7 @@ public partial class PawnController
 		}
 
 		Wallrunning = traceWall.side;
-		previousWallrunSide = traceWall.side;
+		previousWallrunNormal = traceWall.traceResult.Normal;
 
 		wallrunSinceJumping = true;
 		parkouredBeforeLanding = true;

--- a/code/pawn/PawnController.cs
+++ b/code/pawn/PawnController.cs
@@ -46,7 +46,8 @@ public partial class PawnController : EntityComponent<Pawn>
 	private bool debugMode => false;
 	private bool parkouredSinceJumping = false;
 	private bool wallrunSinceJumping = false;
-	private WallRunSide previousWallrunSide = WallRunSide.None;
+	// private WallRunSide previousWallrunSide = WallRunSide.None;
+	private Vector3 previousWallrunNormal = Vector3.Zero;
 	private bool parkouredBeforeLanding = false;
 
 	HashSet<string> ControllerEvents = new( StringComparer.OrdinalIgnoreCase );


### PR DESCRIPTION
Adds #86
- Use wall surface normal instead of wallrun side for comparing the previous wall